### PR TITLE
fixed a bug in nginx config

### DIFF
--- a/bench/config/nginx.py
+++ b/bench/config/nginx.py
@@ -83,6 +83,10 @@ def prepare_sites(config, bench_path):
 		else:
 			if not site.get("port"):
 				site["port"] = 80
+				while(site["port"] in ports_in_use)
+				{
+					site["port"]++
+				}
 
 			if site["port"] in ports_in_use:
 				raise Exception("Port {0} is being used by another site {1}".format(site["port"], ports_in_use[site["port"]]))


### PR DESCRIPTION
i found a bug when the user of the bench is currently using a dns-multitenant setup and he has multiple sites, and then he decides to switch to multiport setup, then all the sites present on the server get assigned the same port "80" and you can't change the port of any site due to the exception "Port 80 is being used by..." 

so i fixed the bug by assigning a new port number that is not in use to every unassigned site, so afterwards the user can set his own port number for each site without having to face this exception and failing at this task
